### PR TITLE
Send file contents to LLM whenever the error mentions a file for deeper debug

### DIFF
--- a/debugger.py
+++ b/debugger.py
@@ -5,7 +5,20 @@ from llm import AnthropicLLM, Conversation
 
 class Debugger:
     DELIMITER = "#######"
-    SYSTEM_PROMPT = f"""
+    FILE_DETECTION_SYSTEM_PROMPT = f"""
+    You are an experienced engineer who is helping a junior engineer to debug the error.
+
+    {DELIMITER} Instruction:
+    - Carefully read the command run by the user and the resulting error.
+    - Identify if the error is related to a specific file. If so, return the file path. If not, return NO_FILE.
+
+    {DELIMITER} Output:
+    <filepath>
+    {{Just return the file path as a string. If not related to any file, return NO_FILE. Do not add any other information.}}
+    </filepath>
+    """
+
+    DEBUG_SYSTEM_PROMPT = f"""
     You are an experienced engineer who is helping a junior engineer to debug the error.
 
     {DELIMITER} Instruction:
@@ -28,7 +41,32 @@ class Debugger:
     def __init__(self):
         self.llm = AnthropicLLM()
 
-    def generate_user_prompt(self, command: str, error: str, code_snippet: Optional[str]) -> str:
+    def generate_user_prompt_for_file_detection(self, command: str, error: str) -> str:
+        return f"""
+        Here is the command and error message:
+        ===============
+        <command>
+        {command}
+        </command>
+        <error>
+        {error}
+        </error>
+        """
+
+    def detect_file_path(self, command: str, error: str) -> Optional[str]:
+        user_prompt = self.generate_user_prompt_for_file_detection(command, error)
+        conversation = Conversation()
+        conversation.add_user_message(user_prompt)
+        messages = conversation.to_dict()
+
+        llm_response = self.llm.generate_conversation_stream_print(self.FILE_DETECTION_SYSTEM_PROMPT, messages, model="small")
+        parsed_response = self.parse_response(llm_response)
+        filepath = parsed_response["filepath"]
+        if filepath == "NO_FILE":
+            return None
+        return filepath
+
+    def generate_user_prompt_for_debug(self, command: str, error: str, code_snippet: Optional[str]) -> str:
         if code_snippet is None:
             return f"""
             Here is the command and error message:
@@ -57,12 +95,12 @@ class Debugger:
             """
 
     def debug(self, command: str, error: str, code_snippet: Optional[str] = None) -> Dict[str, Any]:
-        user_prompt = self.generate_user_prompt(command, error, code_snippet)
+        user_prompt = self.generate_user_prompt_for_debug(command, error, code_snippet)
         conversation = Conversation()
         conversation.add_user_message(user_prompt)
         messages = conversation.to_dict()
-        
-        llm_response = self.llm.generate_conversation_stream_print(self.SYSTEM_PROMPT, messages, model="latest_large")
+
+        llm_response = self.llm.generate_conversation_stream_print(self.DEBUG_SYSTEM_PROMPT, messages, model="latest_large")
         parsed_response = self.parse_response(llm_response)
         
         return parsed_response
@@ -79,6 +117,7 @@ class Debugger:
                 'thinking': r'<thinking>(.*?)</thinking>',
                 'recommendation': r'<recommendation>(.*?)</recommendation>',
                 # 'reflection': r'<reflection>(.*?)</reflection>'
+                'filepath': r'<filepath>(.*?)</filepath>'
             }
             
             for key, pattern in patterns.items():

--- a/debugger.py
+++ b/debugger.py
@@ -1,5 +1,5 @@
 import re
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
 from llm import AnthropicLLM, Conversation
 
@@ -28,22 +28,36 @@ class Debugger:
     def __init__(self):
         self.llm = AnthropicLLM()
 
-    def generate_user_prompt(self, error: str, code_snippet: str) -> str:
-        return f"""
-        Here is the error message and relevant code:
-        
-        ===============
-        <error>
-        {error}
-        </error>
-        <code_snippet>
-        {code_snippet}
-        </code_snippet>
-        ===============
-        """
+    def generate_user_prompt(self, command: str, error: str, code_snippet: Optional[str]) -> str:
+        if code_snippet is None:
+            return f"""
+            Here is the command and error message:
+            ===============
+            <command>
+            {command}
+            </command>
+            <error>
+            {error}
+            </error>
+            """
+        else:
+            return f"""
+            Here is the command, error message and relevant code:
+            ===============
+            <command>
+            {command}
+            </command>
+            <error>
+            {error}
+            </error>
+            <code_snippet>
+            {code_snippet}
+            </code_snippet>
+            ===============
+            """
 
-    def debug(self, error: str, code_snippet: str) -> Dict[str, Any]:
-        user_prompt = self.generate_user_prompt(error, code_snippet)
+    def debug(self, command: str, error: str, code_snippet: Optional[str] = None) -> Dict[str, Any]:
+        user_prompt = self.generate_user_prompt(command, error, code_snippet)
         conversation = Conversation()
         conversation.add_user_message(user_prompt)
         messages = conversation.to_dict()

--- a/demo/average.py
+++ b/demo/average.py
@@ -1,0 +1,16 @@
+def calculate_average(numbers):
+    total = 0
+    count = 0
+    for num in numbers:
+        total += num
+        count += 1
+    return total / count
+
+numbers = [1, 2, 3, 4, 5]
+result = calculate_average(numbers)
+print(f"The average is: {result}")
+
+# This line contains the bug
+empty_list = []
+average_of_empty = calculate_average(empty_list)
+print(f"The average of an empty list is: {average_of_empty}")

--- a/terminal.py
+++ b/terminal.py
@@ -1,24 +1,39 @@
 import subprocess
 import sys
+import os
 from debugger import Debugger
 
-def run_command(command):
-    try:
-        result = subprocess.run(command, shell=True, check=True, text=True, capture_output=True)
-        print(result.stdout)
-    except subprocess.CalledProcessError as e:
-        print(e.stderr)
-        print("-" * 100 + "\n" + "Debugging..." + "\n" + "-" * 100)
-        debugger = Debugger()
-        resp = debugger.debug(e.stderr, command)
-        print(resp["recommendation"])
+DEEP_DEBUG_INTERPRETERS: list[str] = ["python"]
 
-def get_command():
-    if len(sys.argv) > 1:
-        return ' '.join(sys.argv[1:])
-    else:
-        print("format: python terminal.py <command>")
-        exit(1)
+class Command:
+    def __init__(self, args: list[str]):
+        if len(args) == 0:
+            print("format: python terminal.py <command>")
+            exit(1)
+        self.raw_command = " ".join(args)
+        self.interpreter = args[0]
+        self.filename = args[1] if len(args) > 1 else None
+        self.args = args[2:] if len(args) > 2 else []
+        self.debugger = Debugger()
+
+    def run(self):
+        try:
+            result = subprocess.run(self.raw_command, shell=True, check=True, text=True, capture_output=True)
+            print(result.stdout)
+        except subprocess.CalledProcessError as e:
+            print(e.stderr)
+            print("-" * 100 + "\n" + "Debugging..." + "\n" + "-" * 100)
+            code_snippet = None
+            if self.interpreter.lower() in DEEP_DEBUG_INTERPRETERS:
+                filepath = f"{os.path.dirname(os.path.abspath(__file__))}/{self.filename}"
+                if os.path.exists(filepath):
+                    with open(filepath, 'r') as file:
+                        code_snippet = file.read()
+                else:
+                    code_snippet = "File not found: " + filepath
+            resp = self.debugger.debug(self.raw_command, e.stderr, code_snippet)
+            print(resp["recommendation"])
 
 if __name__ == "__main__":
-    run_command(get_command())
+    cmd = Command(sys.argv[1:])
+    cmd.run()


### PR DESCRIPTION
We make a quick LLM call to detect if the error contains a filepath. If so, we additionally send the contents of the file to the LLM for debugging. This leads to higher quality debug recommendations.