### PR TITLE
Fix npmjs package

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,30 @@ https://github.com/user-attachments/assets/2a8a6d49-8b98-4319-a8de-16ef6ea23210
 
 ## Installation
 
+There are two ways to setup Always-On Debugger.
+
+### Option 1: Using npm
+
+Step 1: Install the package
+
+```bash
+npm install -g aidebug
+```
+
+Step 2: Setup the API key for Anthropic
+
+```bash
+export ANTHROPIC_API_KEY=<PASTE_YOUR_OWN_API_KEY>
+```
+
+Step 3: Now you can use the `debug` command to debug your commands.
+
+```bash
+debug python average.py
+```
+
+### Option 2: Manual Setup
+
 _Step 1: Clone the repo_
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ Always-On Debugger is a tool that enhances your terminal experience by automatic
 - Captures context and sends it to an AI language model for analysis
 - Provides AI-generated debugging suggestions directly in the terminal
 
-## Setup
+## Installation
+
 _Step 1: Clone the repo_
+
 ```bash
 cd ~
 git clone git@github.com:samarthaggarwal/always-on-debugger.git
@@ -22,12 +24,14 @@ git clone git@github.com:samarthaggarwal/always-on-debugger.git
 
 _Step 2: Update ~/.bashrc_
 Add the following to your ~/.bashrc or ~/.zshrc
+
 ```
 alias debug="python ~/always-on-debugger/terminal.py"
 export ANTHROPIC_API_KEY=<PASTE_YOUR_OWN_API_KEY>
 ```
 
 _Step 3: Source ~/.bashrc or ~/.zshrc . Alternatively, open a new terminal._
+
 ```bash
 source ~/.bashrc
 ```
@@ -37,6 +41,7 @@ source ~/.bashrc
 Just prefix any terminal command with `debug`. That's it, the debugger will automatically kick in when an error is detected and prints the error along with the suggested course of action. Here's an example:
 
 > Normally, the deverlop would only see the error.
+
 ```bash
 [14:57:19] ➜  demo git:(main) ✗ python average.py
 The average is: 3.0
@@ -99,6 +104,7 @@ By implementing one of these solutions, you will prevent the ZeroDivisionError a
 ```
 
 ## How it works?
+
 1. Prefix your terminal commands with `debug`.
 2. If an error occurs, Always-On Debugger automatically captures the context.
 3. The error context is sent to an AI language model for analysis.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aidebug",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/samarthaggarwal/always-on-debugger.git"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "aidebug",
-  "version": "1.0.1",
-  "devDependencies": {
-    "@types/node": "^22.5.4",
-    "ts-node": "^10.9.2"
+  "version": "1.0.2",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/samarthaggarwal/always-on-debugger.git"
   },
+  "homepage": "https://github.com/samarthaggarwal/always-on-debugger",
   "bin": {
     "aod": "./wrapper.js",
     "debug": "./wrapper.js"

--- a/wrapper.js
+++ b/wrapper.js
@@ -8,6 +8,7 @@ const { join } = require('path');
 // npm pack
 // npm i -g aod-0.1.tgz
 // $env:ANTHROPIC_API_KEY = "<key>"
+// npm publish
 
 async function run() {
   const [, , ...args] = argv;


### PR DESCRIPTION
- Remove the brew install + pip install in the npmjs package page. It seemed npmjs put those commands itself on the npmjs package page even if it wasn't part of the repository's readme file. I changed the header of the section from 'Setup' to 'Installation'  and now it shows the page correctly.
- Also linked github page to npmjs package